### PR TITLE
Created click-drag-doubleclick example

### DIFF
--- a/components/examples-hooks.js
+++ b/components/examples-hooks.js
@@ -49,4 +49,9 @@ export default [
     title: 'Compilation',
     tags: ['useSprings'],
   },
+  {
+    name: 'hooks/click-drag-doubleclick',
+    title: 'Click Drag Double-Click',
+    tags: ['useSprings'],
+  },
 ]

--- a/demos/hooks/click-drag-doubleclick/helper.js
+++ b/demos/hooks/click-drag-doubleclick/helper.js
@@ -1,0 +1,22 @@
+export const DRAG_STATUS = {
+  NONE: 'none',
+  CLICKED: 'clicked',
+  DOUBLE_CLICKED: 'double clicked',
+  DRAG_STARTED: 'drag started',
+  DRAG_ENDED: 'drag ended',
+}
+
+export const getDragStatusColor = dragStatus => {
+  switch (dragStatus) {
+    case DRAG_STATUS.CLICKED:
+      return 'lightgreen'
+    case DRAG_STATUS.DOUBLE_CLICKED:
+      return 'lightskyblue'
+    case DRAG_STATUS.DRAG_STARTED:
+    case DRAG_STATUS.DRAG_ENDED:
+      return 'lightsalmon'
+    case DRAG_STATUS.NONE:
+    default:
+      return 'grey'
+  }
+}

--- a/demos/hooks/click-drag-doubleclick/index.js
+++ b/demos/hooks/click-drag-doubleclick/index.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { useSpring, animated } from 'react-spring'
+import { useGesture } from 'react-use-gesture'
+import './styles.css'
+import { DRAG_STATUS, getDragStatusColor } from './helper.js'
+
+const DOUBLE_CLICK_TIME_THRESHOLD = 250
+
+export default function ClickDragDoubleClick() {
+  const [clickCount, setClickCount] = React.useState(0)
+  const [dragStatus, setDragStatus] = React.useState(DRAG_STATUS.NONE)
+  const isDragging = React.useRef(false)
+  const isDoubleClicked = React.useRef(false)
+  const previousClickTimestamp = React.useRef(performance.now())
+  const [springProps, setSpring] = useSpring(() => ({ x: 0, y: 0, scale: 1 }))
+  const gestureBinds = useGesture(
+    {
+      onDrag: ({ down, movement: [mx, my], first, last }) => {
+        if (first) {
+          isDragging.current = true
+          setDragStatus(DRAG_STATUS.DRAG_STARTED)
+        } else if (last) {
+          requestAnimationFrame(() => (isDragging.current = false))
+          setDragStatus(DRAG_STATUS.DRAG_ENDED)
+        }
+        setSpring({
+          x: down ? mx : 0,
+          y: down ? my : 0,
+          scale: down ? 1.4 : 1,
+        })
+      },
+      onClick: e => {
+        if (isDragging.current) return
+        e.stopPropagation()
+        const now = performance.now()
+        const clickDeltaTime = now - previousClickTimestamp.current
+        if (
+          isDoubleClicked.current ||
+          clickDeltaTime >= DOUBLE_CLICK_TIME_THRESHOLD
+        ) {
+          isDoubleClicked.current = false
+          setDragStatus(DRAG_STATUS.CLICKED)
+        } else {
+          isDoubleClicked.current = true
+          setDragStatus(DRAG_STATUS.DOUBLE_CLICKED)
+        }
+        previousClickTimestamp.current = now
+        setClickCount(c => c + 1)
+      },
+    },
+    { dragDelay: 1000 }
+  )
+
+  return (
+    <>
+      <animated.div
+        className="square"
+        {...gestureBinds()}
+        style={{
+          ...springProps,
+          backgroundColor: getDragStatusColor(dragStatus),
+          cursor:
+            dragStatus === DRAG_STATUS.DRAG_STARTED ? 'grabbing' : 'pointer',
+        }}
+      />
+      <aside className="status">
+        <div>Drag Status: {dragStatus}</div>
+        <div>Click Count: {clickCount}</div>
+      </aside>
+    </>
+  )
+}

--- a/demos/hooks/click-drag-doubleclick/styles.css
+++ b/demos/hooks/click-drag-doubleclick/styles.css
@@ -1,0 +1,14 @@
+.square {
+  position: relative;
+  top: calc(50% - 60px);
+  width: 120px;
+  height: 120px;
+  margin: 0 auto;
+  border-radius: 16px;
+}
+
+aside {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}


### PR DESCRIPTION
Based on https://github.com/react-spring/react-use-gesture/issues/66

**Requires react-use-gesture@6.0.7^**

I noticed some of the other examples have already been updated to `react-use-gesture` 6+, but the dependencies are still set to v5. I checked out the breaking changes from v6, and there really isn't much left to update. Should I go ahead and make these changes from v5 -> v6 for the remaining examples (and update the `package.json` and `yarn.lock`)?