### PR TITLE
Update/react use gesture v6

### DIFF
--- a/components/examples-hooks.js
+++ b/components/examples-hooks.js
@@ -45,11 +45,6 @@ export default [
     tags: ['useSprings'],
   },
   {
-    name: 'hooks/compilation',
-    title: 'Compilation',
-    tags: ['useSprings'],
-  },
-  {
     name: 'hooks/click-drag-doubleclick',
     title: 'Click Drag Double-Click',
     tags: ['useSprings'],

--- a/components/examples-hooks.js
+++ b/components/examples-hooks.js
@@ -49,4 +49,9 @@ export default [
     title: 'Compilation',
     tags: ['useSprings'],
   },
+  {
+    name: 'hooks/click-drag-doubleclick',
+    title: 'Click Drag Double-Click',
+    tags: ['useSprings'],
+  },
 ]

--- a/demos/hooks/click-drag-doubleclick/helper.js
+++ b/demos/hooks/click-drag-doubleclick/helper.js
@@ -1,0 +1,22 @@
+export const DRAG_STATUS = {
+  NONE: 'none',
+  CLICKED: 'clicked',
+  DOUBLE_CLICKED: 'double clicked',
+  DRAG_STARTED: 'drag started',
+  DRAG_ENDED: 'drag ended',
+}
+
+export const getDragStatusColor = dragStatus => {
+  switch (dragStatus) {
+    case DRAG_STATUS.CLICKED:
+      return 'lightgreen'
+    case DRAG_STATUS.DOUBLE_CLICKED:
+      return 'lightskyblue'
+    case DRAG_STATUS.DRAG_STARTED:
+    case DRAG_STATUS.DRAG_ENDED:
+      return 'lightsalmon'
+    case DRAG_STATUS.NONE:
+    default:
+      return 'grey'
+  }
+}

--- a/demos/hooks/click-drag-doubleclick/index.js
+++ b/demos/hooks/click-drag-doubleclick/index.js
@@ -52,7 +52,7 @@ export default function ClickDragDoubleClick() {
   )
 
   return (
-    <>
+    <div className="flex-content">
       <animated.div
         className="square"
         {...gestureBinds()}
@@ -67,6 +67,6 @@ export default function ClickDragDoubleClick() {
         <div>Drag Status: {dragStatus}</div>
         <div>Click Count: {clickCount}</div>
       </aside>
-    </>
+    </div>
   )
 }

--- a/demos/hooks/click-drag-doubleclick/index.js
+++ b/demos/hooks/click-drag-doubleclick/index.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { useSpring, animated } from 'react-spring'
+import { useGesture } from 'react-use-gesture'
+import './styles.css'
+import { DRAG_STATUS, getDragStatusColor } from './helper.js'
+
+const DOUBLE_CLICK_TIME_THRESHOLD = 250
+
+export default function ClickDragDoubleClick() {
+  const [clickCount, setClickCount] = React.useState(0)
+  const [dragStatus, setDragStatus] = React.useState(DRAG_STATUS.NONE)
+  const isDragging = React.useRef(false)
+  const isDoubleClicked = React.useRef(false)
+  const previousClickTimestamp = React.useRef(performance.now())
+  const [springProps, setSpring] = useSpring(() => ({ x: 0, y: 0, scale: 1 }))
+  const gestureBinds = useGesture(
+    {
+      onDrag: ({ down, movement: [mx, my], first, last }) => {
+        if (first) {
+          isDragging.current = true
+          setDragStatus(DRAG_STATUS.DRAG_STARTED)
+        } else if (last) {
+          requestAnimationFrame(() => (isDragging.current = false))
+          setDragStatus(DRAG_STATUS.DRAG_ENDED)
+        }
+        setSpring({
+          x: down ? mx : 0,
+          y: down ? my : 0,
+          scale: down ? 1.4 : 1,
+        })
+      },
+      onClick: e => {
+        if (isDragging.current) return
+        e.stopPropagation()
+        const now = performance.now()
+        const clickDeltaTime = now - previousClickTimestamp.current
+        if (
+          isDoubleClicked.current ||
+          clickDeltaTime >= DOUBLE_CLICK_TIME_THRESHOLD
+        ) {
+          isDoubleClicked.current = false
+          setDragStatus(DRAG_STATUS.CLICKED)
+        } else {
+          isDoubleClicked.current = true
+          setDragStatus(DRAG_STATUS.DOUBLE_CLICKED)
+        }
+        previousClickTimestamp.current = now
+        setClickCount(c => c + 1)
+      },
+    },
+    { dragDelay: 1000 }
+  )
+
+  return (
+    <>
+      <animated.div
+        className="square"
+        {...gestureBinds()}
+        style={{
+          ...springProps,
+          backgroundColor: getDragStatusColor(dragStatus),
+          cursor:
+            dragStatus === DRAG_STATUS.DRAG_STARTED ? 'grabbing' : 'pointer',
+        }}
+      />
+      <aside className="status">
+        <div>Drag Status: {dragStatus}</div>
+        <div>Click Count: {clickCount}</div>
+      </aside>
+    </>
+  )
+}

--- a/demos/hooks/click-drag-doubleclick/styles.css
+++ b/demos/hooks/click-drag-doubleclick/styles.css
@@ -1,6 +1,4 @@
 .square {
-  position: relative;
-  top: calc(50% - 60px);
   width: 120px;
   height: 120px;
   margin: 0 auto;
@@ -11,4 +9,5 @@ aside {
   position: absolute;
   top: 10px;
   left: 10px;
+  font-size: 14.5px;
 }

--- a/demos/hooks/click-drag-doubleclick/styles.css
+++ b/demos/hooks/click-drag-doubleclick/styles.css
@@ -1,0 +1,14 @@
+.square {
+  position: relative;
+  top: calc(50% - 60px);
+  width: 120px;
+  height: 120px;
+  margin: 0 auto;
+  border-radius: 16px;
+}
+
+aside {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}

--- a/demos/hooks/wheel/index.js
+++ b/demos/hooks/wheel/index.js
@@ -5,18 +5,21 @@ import { clamp } from 'lodash'
 import './styles.css'
 
 export default function Wheel() {
-  const [{ clampY, localY }, set] = useSpring(() => ({ clampY: 0, localY: 0 }))
+  const [{ clampY, offsetY }, set] = useSpring(() => ({
+    clampY: 0,
+    offsetY: 0,
+  }))
 
   const bind = useWheel(
-    ({ first, local: [, ly], delta: [, dy], memo = clampY.getValue() }) => {
-      set({ clampY: clamp(dy + memo, -500, 500), localY: ly, immediate: true })
+    ({ first, offset: [, y], movement: [, my], memo = clampY.getValue() }) => {
+      set({ clampY: clamp(my + memo, -500, 500), offsetY: y, immediate: true })
       return memo
     }
   )
   return (
     <div className="wheel" {...bind()}>
       <animated.div>{clampY}</animated.div>
-      <animated.div>{localY}</animated.div>
+      <animated.div>{offsetY}</animated.div>
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-feather": "^1.1.6",
     "react-loadable": "^5.5.0",
     "react-spring": "^9.0.0-beta.34",
-    "react-use-gesture": "^5.2.3",
+    "react-use-gesture": "^6.0.9",
     "resize-observer-polyfill": "^1.5.1",
     "styled-components": "^4.1.3",
     "vec-la": "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4893,10 +4893,10 @@ react-spring@^9.0.0-beta.34:
     "@react-spring/web" "^9.0.0-beta.34"
     "@react-spring/zdog" "^9.0.0-beta.33"
 
-react-use-gesture@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-5.2.3.tgz#3505b45f1076963040ed6204a81ee5f252d55b36"
-  integrity sha512-aXpit9o3EhmlM/erBu9wzWNrx7Wbms/ha38I/XSF+ybUdZ9idhWjy4LODGfj+wqMNNdmphLfYLPO+WfApYXAiA==
+react-use-gesture@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-6.0.9.tgz#39c307914b6e7e6b0c7f2297e99284de612b9211"
+  integrity sha512-cG8RIpRYGqPhbTZasE3Gfchr8d09hSWDfhFIPMTY2dSznMcD1Ar8BRlB7V1hYs6SRpZ86//ojLI9B/CrSgEpnQ==
 
 react@^16.8.1:
   version "16.8.6"


### PR DESCRIPTION
* Bump react-use-gesture dependency to v6, update yarn.lock
* Remove compilation demo entry from example-hooks.js (demo was deleted in #22)
* Update wheel demo to react-use-gesture v6
* Create click-drag-doubleclick based on react-spring/react-use-gesture#66

David already did all the hard work for v6 - there was only the `wheel` demo left to update :)